### PR TITLE
fix: multi region certs route53 verify records

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,27 +16,20 @@ locals {
   dvo = tolist(aws_acm_certificate.this.domain_validation_options)[0]
 }
 
-# Check if the Route 53 record already exists
-data "aws_route53_record" "existing_verify" {
-  zone_id = var.zone_id
-  name    = local.dvo.resource_record_name
-  type    = local.dvo.resource_record_type
-}
-
-# Conditionally create the Route 53 record only if it doesn't already exist
+# Create unique record name based on the region
 resource "aws_route53_record" "verify" {
-  count   = length(data.aws_route53_record.existing_verify.id) == 0 ? 1 : 0
-  name    = local.dvo.resource_record_name
-  records = [local.dvo.resource_record_value]
-  type    = local.dvo.resource_record_type
-  zone_id = var.zone_id
-  ttl     = 60
+  for_each = var.create_record_in_region ? { for r in [var.region] : r => r } : {}
+  name     = local.dvo.resource_record_name
+  records  = [local.dvo.resource_record_value]
+  type     = local.dvo.resource_record_type
+  zone_id  = var.zone_id
+  ttl      = 60
 }
 
 # Wait for the certificate to be issued
 resource "aws_acm_certificate_validation" "this" {
   certificate_arn         = aws_acm_certificate.this.arn
-  validation_record_fqdns = aws_route53_record.verify[*].fqdn
+  validation_record_fqdns = [for record in aws_route53_record.verify : record.fqdn]
 }
 
 output "arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,11 +19,7 @@ EOF
   default     = true
 }
 
-variable "create_record_in_region" {
+variable "create_record" {
   type    = bool
   default = true
-}
-
-variable "region" {
-  type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ EOF
   default     = true
 }
 
-variable "create_record" {
+variable "validate_route53" {
   type    = bool
   default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,12 @@ See https://docs.aws.amazon.com/acm/latest/userguide/acm-concepts.html#concept-t
 EOF
   default     = true
 }
+
+variable "create_record_in_region" {
+  type    = bool
+  default = true
+}
+
+variable "region" {
+  type = string
+}


### PR DESCRIPTION
To address issue 

```
[Error: 
creating Route 53 Record: InvalidChangeBatch: [Tried to create resource record set [name='_69859c9990dc1526ae9775351b7b130a.prod.evooq.ch.', type='CNAME'] but it already
 exists]
│ 	status code: 400, request id: 5ad66bd4-5f49-4722-a372-9fc64b394875
│ 
│   with module.wildcard_certificates_us["prod"].aws_route53_record.verify,
│   on .terraform/modules/wildcard_certificates_us/main.tf line 20, in resource "aws_route53_record" "verify":
│   20: resource "aws_route53_record" "verify" {
│ 
╵
╷](https://edgelab.scalr.io/v2/e/env-v0o0mb7dkjgu3k5e1/workspaces/ws-v0o0n9eo9lh64nv8i/runs/run-v0ogbcuaeakg6nnvt/?step=apply)
```